### PR TITLE
fix(cost): Total Cost KPI sums real costs only (>0), not -1 sentinels

### DIFF
--- a/v2.0.0/pages/Cost_and_Performance.py
+++ b/v2.0.0/pages/Cost_and_Performance.py
@@ -61,11 +61,15 @@ def main():
 
     with col1:
         if has_cost:
-            total_cost = df['total_cost'].sum()
+            # Sum only real costs (> 0). Traces fetched without the Langfuse
+            # 'metrics' field group carry total_cost = -1.0 (a sentinel, not a
+            # cost); summing those raw drove this KPI negative. Every other cost
+            # metric on this page already filters > 0 — this one now matches.
+            total_cost = df[df['total_cost'] > 0]['total_cost'].sum()
             st.metric(
                 label="💰 Total Cost",
                 value=f"${total_cost:.4f}",
-                help="Total cost across all traces"
+                help="Total cost across all traces (real costs only; -1 sentinels excluded)"
             )
 
     with col2:

--- a/v2.0.0/utils/data_loader.py
+++ b/v2.0.0/utils/data_loader.py
@@ -292,7 +292,7 @@ def calculate_kpis(merged_df: pd.DataFrame, data: Dict[str, pd.DataFrame]) -> Di
         # Cost & performance
         'avg_latency': merged_df['latency'].mean() if 'latency' in merged_df.columns and merged_df['latency'].notna().any() else None,
         'median_latency': merged_df['latency'].median() if 'latency' in merged_df.columns and merged_df['latency'].notna().any() else None,
-        'total_cost': merged_df['total_cost'].sum() if 'total_cost' in merged_df.columns and merged_df['total_cost'].notna().any() else None,
+        'total_cost': merged_df.loc[merged_df['total_cost'] > 0, 'total_cost'].sum() if 'total_cost' in merged_df.columns and merged_df['total_cost'].notna().any() else None,
         'avg_cost_per_question': merged_df['total_cost'].mean() if 'total_cost' in merged_df.columns and merged_df['total_cost'].notna().any() else None,
         'unique_users': merged_df['user_id'].nunique() if 'user_id' in merged_df.columns else 0,
         'unique_sessions': merged_df['session_id'].nunique() if 'session_id' in merged_df.columns else 0,


### PR DESCRIPTION
Traces fetched without the Langfuse 'metrics' field group carry total_cost=-1.0 (a sentinel). The Total Cost KPI (Cost_and_Performance.py) and the data_loader KPI summed total_cost raw, including those sentinels -> negative total (e.g. -$3171). Every other cost metric already filtered >0; these now match. Root data fix is in pathway-indexer (fetch 'metrics'); this makes the dashboard robust to any -1 sentinels regardless.